### PR TITLE
Added a white label to text and symbolic icons in the Media Player Selector Pop Up

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -491,34 +491,6 @@ export class MusicController {
 
                     p._nameOwnerId = p.connect('notify::g-name-owner', () => { this._scan(); });
 
-                    p._identity = null;
-                    
-                    this._connection.call(
-                      p._busName,
-                      '/org/mpris/MediaPlayer2',
-                      'org.freedesktop.DBus.Properties',
-                      'GetAll',
-                      new GLib.Variant('(s)', ['org.mpris.MediaPlayer2']),
-                      null, Gio.DBusCallFlags.NONE, -1, null,
-                      (conn, asyncRes) => {
-                        try {
-                          let result = conn.call_finish(asyncRes);
-                          if (result) {
-                            let props = result.deep_unpack()[0];
-                            if (props['Identity']){
-                              let v = props['Identity'];
-                              p._identity = v instanceof GLib.Variant ? v.unpack() : v;
-                            }
-                            if (props['DesktopEntry']){
-                              let v = props['DesktopEntry'];
-                              p._desktopEntry = v instanceof GLib.Variant ? v.unpack() : v;
-                            }
-                          }
-                        } catch (e) {}
-                      }
-
-                    );
-
                     this._proxies.set(name, p);
                     
                     this._connection.call(

--- a/ui.js
+++ b/ui.js
@@ -2017,13 +2017,12 @@ class PlayerSelectorMenu extends St.Widget {
             
             // JAVÍTÁS 2: App nevének és ikonjának kinyerése a busName-ből (pl. 'spotify', 'firefox')
             let rawAppName = busName.replace('org.mpris.MediaPlayer2.', '').split('.')[0];
-            let identity = proxy._identity || (rawAppName.charAt(0).toUpperCase() + rawAppName.slice(1));
-            let iconName = proxy._desktopEntry || rawAppName.toLowerCase();
+            let identity = rawAppName.charAt(0).toUpperCase() + rawAppName.slice(1);
             
             let btnContent = new St.BoxLayout({ vertical: false, style: 'spacing: 12px;' });
             
             let icon = new St.Icon({ 
-                icon_name: iconName(), 
+                icon_name: rawAppName.toLowerCase(), 
                 fallback_icon_name: 'audio-x-generic-symbolic',
                 icon_size: 24, style: 'color: white', 
             });


### PR DESCRIPTION
Closes #36 by adding a white label to the text and symbolic icons in the Media Player Selector Pop-up.

Open to other solutions!