### PR TITLE
Differentiate lyrics fetch errors from 'no lyrics found'

### DIFF
--- a/src/LyricsClient.js
+++ b/src/LyricsClient.js
@@ -53,8 +53,8 @@ export class LyricsClient {
     try {
       const url = `https://lrclib.net/api/get?track_name=${encodeURIComponent(title || '')}&artist_name=${encodeURIComponent(artist || '')}&album_name=${encodeURIComponent(album || '')}&duration=${duration}`;
       let msg;
-      try { msg = Soup.Message.new("GET", url); } catch (_e) { return null; }
-      if (!msg) return null;
+      try { msg = Soup.Message.new("GET", url); } catch (_e) { throw new Error('Failed to create request'); }
+      if (!msg) throw new Error('Failed to create request');
       const bytes = await this._session.send_and_read_async(msg, GLib.PRIORITY_DEFAULT, null);
 
       let exactItem = null;
@@ -89,7 +89,7 @@ export class LyricsClient {
 
     } catch (e) {
       console.debug(`[Dynamic Music Pill] Lyrics fetch error: ${e.message}`);
-      return null;
+      throw e; // re-throw so caller can distinguish error from "no lyrics found"
     }
   }
 
@@ -99,8 +99,8 @@ export class LyricsClient {
     try {
       const url = `https://lrclib.net/api/search?q=${encodeURIComponent((title || '') + " " + (artist || ''))}`;
       let msg;
-      try { msg = Soup.Message.new("GET", url); } catch (_e) { return []; }
-      if (!msg) return [];
+      try { msg = Soup.Message.new("GET", url); } catch (_e) { throw new Error('Failed to create search request'); }
+      if (!msg) throw new Error('Failed to create search request');
       const bytes = await this._session.send_and_read_async(msg, GLib.PRIORITY_DEFAULT, null);
       const data = JSON.parse(decode(bytes.get_data()));
       return Array.isArray(data)
@@ -108,7 +108,7 @@ export class LyricsClient {
         : [];
     } catch (e) {
       console.debug(`[Dynamic Music Pill] Lyrics search error: ${e.message}`);
-      return [];
+      throw e; // re-throw so caller can distinguish error from "no results"
     }
   }
 

--- a/src/uiExpandedPlayer.js
+++ b/src/uiExpandedPlayer.js
@@ -1202,7 +1202,7 @@ export const ExpandedPlayer = GObject.registerClass(
                     }).catch(() => {
                         if (page === this._currentSubPage && page.get_parent())
                             if (!lyricsWidget.is_finalized || !lyricsWidget.is_finalized())
-                                lyricsWidget.showEmpty();
+                                lyricsWidget.showError();
                     });
                 }
             }

--- a/src/uiLyricsWidget.js
+++ b/src/uiLyricsWidget.js
@@ -83,6 +83,11 @@ export const LyricsWidget = GObject.registerClass(
             this.queue_repaint();
         }
 
+        showError() {
+            this._fullReset('error');
+            this.queue_repaint();
+        }
+
         setLyrics(lyrics) {
             if (!lyrics || lyrics.length === 0) { this.showEmpty(); return; }
             this._fullReset('lyrics');
@@ -449,7 +454,10 @@ export const LyricsWidget = GObject.registerClass(
             const R = this._fgR, G = this._fgG, B = this._fgB;
 
             if (this._state !== 'lyrics') {
-                let msg = this._state === 'loading' ? '♫  Fetching lyrics…' : 'No lyrics found';
+                let msg;
+                if (this._state === 'loading') msg = '♫  Fetching lyrics…';
+                else if (this._state === 'error') msg = '⚠  Could not fetch lyrics';
+                else msg = 'No lyrics found';
                 let layout = PangoCairo.create_layout(cr);
                 layout.set_alignment(Pango.Alignment.CENTER);
                 layout.set_font_description(


### PR DESCRIPTION
Currently, network errors (SSL failures, DNS issues, etc.) are silently swallowed and shown as 'No lyrics found', which is misleading. This change:

- Re-throws errors from LyricsClient so callers can distinguish between a genuine 'no lyrics' response and a fetch failure
- Adds showError() state to LyricsWidget displaying 'Could not fetch lyrics'
- Updates ExpandedPlayer to call showError() instead of showEmpty() on catch

This gives users clear feedback when lyrics can't be loaded due to network or server issues, rather than wrongly implying the song has no lyrics.

Especially important since lrclib.net is currently inaccessible due to a certificate expiration.

*Disclosure: Generated by Kimi K2.6 with human oversight*