### PR TITLE
Track duration of lyrics (consider blank lines!)

### DIFF
--- a/src/LyricsClient.js
+++ b/src/LyricsClient.js
@@ -113,18 +113,29 @@ export class LyricsClient {
   }
 
   _parseLRC(lrcText) {
-    const lines = [];
     const regex = /\[(\d{2}):(\d{2})\.(\d{2,3})\](.*)/;
-    lrcText.split("\n").forEach((line) => {
+
+    const all = [];
+    for (const line of lrcText.split("\n")) {
       const match = line.match(regex);
       if (match) {
         const time =
           parseInt(match[1]) * 60 * 1000 +
           parseInt(match[2]) * 1000 +
           parseFloat("0." + match[3]) * 1000;
-        if (match[4].trim()) lines.push({ time, text: match[4].trim() });
+        all.push({ time, text: match[4].trim() });
       }
-    });
+    }
+
+    const lines = [];
+    for (let i = 0; i < all.length; i++) {
+      const entry = all[i];
+      if (!entry.text) continue;
+      const nextTime = i + 1 < all.length ? all[i + 1].time : entry.time + 5000;
+      const raw = (nextTime - entry.time) / 1000;
+      entry.duration = Math.min(raw, entry.text.length / 5);
+      lines.push(entry);
+    }
     return lines;
   }
 

--- a/src/LyricsClient.js
+++ b/src/LyricsClient.js
@@ -133,7 +133,7 @@ export class LyricsClient {
       if (!entry.text) continue;
       const nextTime = i + 1 < all.length ? all[i + 1].time : entry.time + 5000;
       const raw = (nextTime - entry.time) / 1000;
-      entry.duration = Math.min(raw, entry.text.length / 5);
+      entry.duration = Math.min(raw, entry.text.length / 4);
       lines.push(entry);
     }
     return lines;

--- a/src/controller.js
+++ b/src/controller.js
@@ -1261,21 +1261,17 @@ export class MusicController {
             }
         }
 
-        if (currentIndex >= 0 && currentIndex !== this._lastLyricIndex) {
+        if (currentIndex >= 0) {
+            const currentLine = this._fetchedLyricsData[currentIndex];
+            if (positionMs > currentLine.time + currentLine.duration * 1000)
+                currentIndex = -1;
+        }
+
+        if (currentIndex !== this._lastLyricIndex) {
             this._lastLyricIndex = currentIndex;
-
-            let currentLine = this._fetchedLyricsData[currentIndex];
-            let durationSec = 5;
-            if (currentIndex + 1 < this._fetchedLyricsData.length) {
-                durationSec = (this._fetchedLyricsData[currentIndex + 1].time - currentLine.time) / 1000;
-            }
-
-            let lrc = {
-                sender: "lrclib",
-                content: currentLine.text,
-                time: durationSec,
-            };
-            this._pill.setLyric(lrc);
+            this._pill.setLyric(currentIndex >= 0
+                ? { sender: "lrclib", content: this._fetchedLyricsData[currentIndex].text, time: this._fetchedLyricsData[currentIndex].duration }
+                : null);
         }
     }
 


### PR DESCRIPTION
right now lyrics always scroll away before the next lyric, but usually you want them to scroll away before they end and big instrumentals/solos start. this change adds a `duration` field, which considers the time of the next lyric, time of blank lines, and also a heuristic (4 characters = 1 second of speech) as a backup cap.

*Disclosure: Generated by Kimi K2.6 with human oversight; it works great in my tests*