### PR TITLE
feat: add toggle to hide Auto (Smart Selection) from player selector

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -525,6 +525,7 @@ export default class DynamicMusicPrefs extends ExtensionPreferences {
             valign: Gtk.Align.CENTER
         });
         settings.bind('hide-auto-smart-selection', hideAutoToggle, 'active', Gio.SettingsBindFlags.DEFAULT);
+        settings.bind('popup-show-player-selector', hideAutoRow, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
         hideAutoRow.add_suffix(hideAutoToggle);
         popupGroup.add(hideAutoRow);
 

--- a/prefs.js
+++ b/prefs.js
@@ -24,7 +24,7 @@ export default class DynamicMusicPrefs extends ExtensionPreferences {
             'popup-use-custom-width', 'popup-custom-width', 'player-filter-mode', 'player-filter-list', 'hide-text',
             'fallback-art-path', 'popup-show-visualizer', 'popup-hide-pill-visualizer', 'compatibility-delay',
             'popup-follow-custom-bg', 'popup-follow-custom-text', 'action-hover', 'hover-delay', 'selected-player-bus',
-            'popup-show-player-selector', 'show-pill-border', 'invert-scroll-direction', 'always-show-pill', 'popup-hide-on-leave',
+            'popup-show-player-selector', 'hide-auto-smart-selection', 'show-pill-border', 'invert-scroll-direction', 'always-show-pill', 'popup-hide-on-leave',
             'visualizer-bars', 'enable-lyrics', 'app-name-mapping', 'lyric-fade-enable', 'lyric-fade-duration', 'visualizer-bar-width', 'visualizer-height',
             'popup-visualizer-bars', 'popup-visualizer-bar-width', 'popup-visualizer-height', 'edge-margin', 'popup-vinyl-speed', 'sync-accent-color',
             'enable-custom-buttons', 'custom-button-1', 'custom-button-2', 'playback-history',
@@ -515,6 +515,18 @@ export default class DynamicMusicPrefs extends ExtensionPreferences {
         settings.bind('popup-show-player-selector', popSelectorToggle, 'active', Gio.SettingsBindFlags.DEFAULT);
         popSelectorRow.add_suffix(popSelectorToggle);
         popupGroup.add(popSelectorRow);
+
+        const hideAutoRow = new Adw.ActionRow({
+            title: _('Hide Auto (Smart Selection)'),
+            subtitle: _('Remove the automatic player selection entry from the player selector menu')
+        });
+        const hideAutoToggle = new Gtk.Switch({
+            active: settings.get_boolean('hide-auto-smart-selection'),
+            valign: Gtk.Align.CENTER
+        });
+        settings.bind('hide-auto-smart-selection', hideAutoToggle, 'active', Gio.SettingsBindFlags.DEFAULT);
+        hideAutoRow.add_suffix(hideAutoToggle);
+        popupGroup.add(hideAutoRow);
 
         const popAlbumRow = new Adw.ActionRow({
             title: _('Show Album Title'),

--- a/schemas/org.gnome.shell.extensions.dynamic-music-pill.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dynamic-music-pill.gschema.xml
@@ -48,6 +48,11 @@
       <default>false</default>
       <summary>Show player selector in pop-up</summary>
     </key>
+    <key name="hide-auto-smart-selection" type="b">
+      <default>false</default>
+      <summary>Hide Auto (Smart Selection)</summary>
+      <description>Remove the automatic player selection entry from the player selector menu.</description>
+    </key>
     <key name="popup-follow-custom-bg" type="b">
       <default>false</default>
       <summary>Popup Follows Custom Background Color</summary>

--- a/src/uiPlayerSelector.js
+++ b/src/uiPlayerSelector.js
@@ -145,31 +145,26 @@ export const PlayerSelectorMenu = GObject.registerClass(
                 });
                 _addBtnPressAnim(autoBtn);
 
-                autoBtn.connectObject('button-release-event', (a, e) => {
-                    if (e.get_button() === 8) return Clutter.EVENT_PROPAGATE;
-                    return Clutter.EVENT_PROPAGATE;
-                }, this);
-                autoBtn.connectObject('clicked', () => {
+                const selectAuto = () => {
                     this._settings.set_string('selected-player-bus', '');
                     this._controller._updateUI();
                     this.hide();
-                }, this);
+                };
 
+                autoBtn.connectObject('clicked', selectAuto, this);
                 autoBtn.connectObject('touch-event', (actor, event) => {
                     let type = event.type();
                     if (type === Clutter.EventType.TOUCH_END) {
-                        this._settings.set_string('selected-player-bus', '');
-                        this._controller._updateUI();
-                        this.hide();
+                        selectAuto();
                         return Clutter.EVENT_STOP;
                     }
                     return Clutter.EVENT_PROPAGATE;
                 }, this);
 
-                autoBtn.connect('notify::hover', () => {
+                autoBtn.connectObject('notify::hover', () => {
                     if (this._settings.get_string('selected-player-bus') === '') return;
                     autoBtn.set_style(`margin-bottom: 8px; border-radius: 12px; padding: 10px; background-color: ${autoBtn.hover ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)'}; transition-duration: 150ms;`);
-                });
+                }, this);
 
                 this._box.add_child(autoBtn);
             }

--- a/src/uiPlayerSelector.js
+++ b/src/uiPlayerSelector.js
@@ -127,50 +127,52 @@ export const PlayerSelectorMenu = GObject.registerClass(
 
             let currentSelected = this._settings.get_string('selected-player-bus');
 
-            // ==== Auto (Smart Selection) Button ====
-            let autoContent = new St.BoxLayout({ vertical: false, style: 'spacing: 12px;' });
-            let autoIcon = new St.Icon({ icon_name: 'emblem-system-symbolic', icon_size: 24, style: textColorStyle });
-            let autoLabel = new St.Label({ text: _('Auto (Smart Selection)'), y_align: Clutter.ActorAlign.CENTER, style: textColorStyle });
-            autoContent.add_child(autoIcon);
-            autoContent.add_child(autoLabel);
+            if (!this._settings.get_boolean('hide-auto-smart-selection')) {
+                // ==== Auto (Smart Selection) Button ====
+                let autoContent = new St.BoxLayout({ vertical: false, style: 'spacing: 12px;' });
+                let autoIcon = new St.Icon({ icon_name: 'emblem-system-symbolic', icon_size: 24, style: textColorStyle });
+                let autoLabel = new St.Label({ text: _('Auto (Smart Selection)'), y_align: Clutter.ActorAlign.CENTER, style: textColorStyle });
+                autoContent.add_child(autoIcon);
+                autoContent.add_child(autoLabel);
 
-            let autoBtn = new St.Button({
-                child: autoContent,
-                reactive: true,
-                can_focus: true,
-                track_hover: true,
-                x_expand: true,
-                style: `margin-bottom: 8px; border-radius: 12px; padding: 10px; background-color: ${currentSelected === '' ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.05)'}; transition-duration: 150ms;`
-            });
-            _addBtnPressAnim(autoBtn);
+                let autoBtn = new St.Button({
+                    child: autoContent,
+                    reactive: true,
+                    can_focus: true,
+                    track_hover: true,
+                    x_expand: true,
+                    style: `margin-bottom: 8px; border-radius: 12px; padding: 10px; background-color: ${currentSelected === '' ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.05)'}; transition-duration: 150ms;`
+                });
+                _addBtnPressAnim(autoBtn);
 
-            autoBtn.connectObject('button-release-event', (a, e) => {
-                if (e.get_button() === 8) return Clutter.EVENT_PROPAGATE;
-                return Clutter.EVENT_PROPAGATE;
-            }, this);
-            autoBtn.connectObject('clicked', () => {
-                this._settings.set_string('selected-player-bus', '');
-                this._controller._updateUI();
-                this.hide();
-            }, this);
-
-            autoBtn.connectObject('touch-event', (actor, event) => {
-                let type = event.type();
-                if (type === Clutter.EventType.TOUCH_END) {
+                autoBtn.connectObject('button-release-event', (a, e) => {
+                    if (e.get_button() === 8) return Clutter.EVENT_PROPAGATE;
+                    return Clutter.EVENT_PROPAGATE;
+                }, this);
+                autoBtn.connectObject('clicked', () => {
                     this._settings.set_string('selected-player-bus', '');
                     this._controller._updateUI();
                     this.hide();
-                    return Clutter.EVENT_STOP;
-                }
-                return Clutter.EVENT_PROPAGATE;
-            }, this);
+                }, this);
 
-            autoBtn.connect('notify::hover', () => {
-                if (this._settings.get_string('selected-player-bus') === '') return;
-                autoBtn.set_style(`margin-bottom: 8px; border-radius: 12px; padding: 10px; background-color: ${autoBtn.hover ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)'}; transition-duration: 150ms;`);
-            });
+                autoBtn.connectObject('touch-event', (actor, event) => {
+                    let type = event.type();
+                    if (type === Clutter.EventType.TOUCH_END) {
+                        this._settings.set_string('selected-player-bus', '');
+                        this._controller._updateUI();
+                        this.hide();
+                        return Clutter.EVENT_STOP;
+                    }
+                    return Clutter.EVENT_PROPAGATE;
+                }, this);
 
-            this._box.add_child(autoBtn);
+                autoBtn.connect('notify::hover', () => {
+                    if (this._settings.get_string('selected-player-bus') === '') return;
+                    autoBtn.set_style(`margin-bottom: 8px; border-radius: 12px; padding: 10px; background-color: ${autoBtn.hover ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)'}; transition-duration: 150ms;`);
+                });
+
+                this._box.add_child(autoBtn);
+            }
 
             // ==== Aktive Players Button ====
             for (let [busName, proxy] of this._controller._proxies) {


### PR DESCRIPTION
Adds a preference toggle to remove the "Auto (Smart Selection)" entry from the player selector menu. Users who accidentally hit this option can now disable it.

Changes:
- Add `hide-auto-smart-selection` GSettings key (default: false)
- Gate Auto button rendering in PlayerSelectorMenu.populate() behind the new setting by adding a conditional
- Add prefs toggle row in Pop-up Menu tab near Show Player Selector
- Add key to PREFS_KEYS array

Closes #119 (first part)