### PR TITLE
Fix lyrics never loading by sending a User-Agent

### DIFF
--- a/src/LyricsClient.js
+++ b/src/LyricsClient.js
@@ -6,6 +6,10 @@ const decode = (data) => new TextDecoder().decode(data);
 
 const CJK_RE = /[\u3040-\u9FFF\uAC00-\uD7AF]/;
 
+// lrclib.net sits behind Cloudflare, which 403s requests with no User-Agent,
+// and libsoup sends none by default.
+const USER_AGENT = "dynamic-music-pill (https://github.com/Andbal23/dynamic-music-pill)";
+
 export class LyricsClient {
   constructor() {
     Gio._promisify(
@@ -13,7 +17,7 @@ export class LyricsClient {
       "send_and_read_async",
       "send_and_read_finish",
     );
-    this._session = new Soup.Session();
+    this._session = new Soup.Session({ user_agent: USER_AGENT });
   }
 
 
@@ -114,6 +118,8 @@ export class LyricsClient {
       try { msg = Soup.Message.new("GET", url); } catch (_e) { throw new Error('Failed to create search request'); }
       if (!msg) throw new Error('Failed to create search request');
       const bytes = await this._session.send_and_read_async(msg, GLib.PRIORITY_DEFAULT, null);
+      if (msg.status_code !== Soup.Status.OK)
+        throw new Error(`Search request failed with status ${msg.status_code}`);
       const data = JSON.parse(decode(bytes.get_data()));
       return Array.isArray(data)
         ? data.filter(item => Math.abs((item.duration || 0) - duration) < 5)


### PR DESCRIPTION
lrclib.net is behind Cloudflare, which returns a 403 HTML page to any request that carries no `User-Agent` header. libsoup sends none by default (`session.user_agent` is `null`), so **every** lyrics request from the extension is currently blocked — no track gets lyrics, regardless of whether lrclib has them.

Reproduced with the extension's own `LyricsClient` against lrclib, on the current `gnome50` code:

```
default session.user_agent = null
403  /api/search?q=bohemian%20rhapsody%20queen   cf-ray=a241ce74…-SEA  server=cloudflare
403  /api/get?track_name=Bohemian%20Rhapsody&…   cf-ray=a241ce75…-SEA  server=cloudflare
```

Setting any `User-Agent` on the same session returns 200. lrclib's docs ask clients to identify themselves anyway, so this uses the extension name and repo URL.

The 403 HTML body was also going straight into `JSON.parse`, so the only symptom was an opaque `unexpected character at line 1 column 1` in the debug log. `_fetchCandidates` now checks `status_code` first and reports the real status.

### Testing

Driving `LyricsClient` directly under gjs, before (on `gnome50`):

```
everyone else / phritz @274s    -> THREW: JSON.parse: unexpected character at line 1 column 1
Bohemian Rhapsody / Queen @354s -> THREW: JSON.parse: unexpected character at line 1 column 1
```

After:

```
everyone else / phritz @274s -> 30 lines, first: "Only if I had a song to write about"
nonexistent track / nobody   -> null   (no false positives)
```

Disclosure: Generated by Claude Opus 5 via Claude Code with human oversight.